### PR TITLE
CREW-233 Railsが出力するSQLが廃止予定のメソッドを使用している不具合の修正

### DIFF
--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -80,7 +80,7 @@ module ActiveRecord
 
         def quote(value_, column_=nil)
           if ::RGeo::Feature::Geometry.check_type(value_)
-            "GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(:hex_format => true).generate(value_)},#{value_.srid})"
+            "ST_GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(:hex_format => true).generate(value_)},#{value_.srid})"
           else
             super
           end


### PR DESCRIPTION
## やったこと
> JIRA
https://japantaxi.atlassian.net/browse/CREW-233
- SQLにおいて将来的に廃止予定の`GeomFromWKB`関数を使用していたため、同等の`ST_GeomFromWKB`関数へ変更を行った。

### テスト
- 本ソースはgem扱いで`sydney-api`に取り込まれているため、`sydney-api`ローカル環境のgemインストール先ファイルを修正後のものに置換し、該当のspecを実行することで実行に問題がないことを確認。

🍌gemインストール先ファイル置換
```
➜  activerecord-mysql2spatial-adapter git:(CREW-233-fix-deprecated-sql) ✗ cp -p lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb /Users/hyoshida/work/taxi/taxi-crew-server/vendor/bundle/ruby/2.3.0/bundler/gems/activerecord-mysql2spatial-adapter-ac582083fe67/lib/active_record/connection_adapters/mysql2spatial_adapter/
```

🍎spec実行結果
```
➜  sydney-api git:(master) bundle exec rspec /Users/hyoshida/work/taxi/sydney-api/spec/requests/v1/external_services/japan_taxi/ride_orders_spec.rb
................................................................................

Finished in 5.12 seconds (files took 5.65 seconds to load)
80 examples, 0 failures
```
